### PR TITLE
Fix dialyzer warnings

### DIFF
--- a/src/ex_banking_currency_server.erl
+++ b/src/ex_banking_currency_server.erl
@@ -24,7 +24,7 @@ init(_Args)->
     {ok,#state{currencies=dict:store(Value, 1, dict:new())}}.
 
 
--spec get_coefficient(Currency)->{ok,{Currency, Coefficient::number()}} | currency_not_found |  {error , wrong_arguments} 
+-spec get_coefficient(Currency)->{ok,Coefficient::number()} | currency_not_found |  {error , wrong_arguments}
                                     when Currency:: list() | atom().
 get_coefficient(Currency) when not is_list(Currency) , not is_atom(Currency)->
     {error,invalid_arguments};
@@ -68,7 +68,7 @@ update_currency(Currency,Coefficient)->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%         Handlers    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 handle_cast(stop,State)->
-    {stop,State}.
+    {stop,normal,State}.
 handle_call({get_currency,Currency},_From,State)->
     Reply=case dict:find(Currency, State#state.currencies) of
             error ->currency_does_not_exist;
@@ -85,7 +85,7 @@ handle_call({add_currency,Currency,Coefficient},_From,State)->
     
 
 handle_call({remove_currency,Currency},_From,State)->
-    NewDict=dict:erase(Currency, State),
+    NewDict=dict:erase(Currency, State#state.currencies),
     {reply,{ok,{removed,Currency}},State#state{currencies=NewDict}};
 
 
@@ -95,4 +95,3 @@ handle_call({update_currency,Currency,Coefficient},_From,State)->
                 {ok,_}-> NewDict=dict:store(Currency, Coefficient,State#state.currencies),
                          {reply,{ok,{updated,Currency}},State#state{currencies=NewDict}}
     end.
-   


### PR DESCRIPTION
```
/Users/iqltd/clones/BankingApp/src/ex_banking_account.erl:75: Function throttle/1 will never be called

/Users/iqltd/clones/BankingApp/src/ex_banking_client.erl:48: The call erlang:'/'
         (BalanceInBaseCurrency :: any(),
          Coefficient :: {atom() | [any()], number()}) will never return since it differs in the 2nd argument from the success typing arguments: 
         (number(),
          number())

/Users/iqltd/clones/BankingApp/src/ex_banking_client.erl:56: The call erlang:'*'
         (Amount :: any(),
          Coefficient :: {atom() | [any()], number()}) will never return since it differs in the 2nd argument from the success typing arguments: 
         (number(),
          number())

/Users/iqltd/clones/BankingApp/src/ex_banking_client.erl:65: The call erlang:'*'
         (Amount :: any(),
          Coefficient :: {atom() | [any()], number()}) will never return since it differs in the 2nd argument from the success typing arguments: 
         (number(),
          number())

/Users/iqltd/clones/BankingApp/src/ex_banking_client.erl:73: The call erlang:'*'
         (Amount :: any(),
          Coefficient :: {atom() | [any()], number()}) will never return since it differs in the 2nd argument from the success typing arguments: 
         (number(),
          number())

/Users/iqltd/clones/BankingApp/src/ex_banking_client.erl:98: Function handle_send/4 will never be called

/Users/iqltd/clones/BankingApp/src/ex_banking_client.erl:102: Function handle_withdraw_result/4 will never be called

/Users/iqltd/clones/BankingApp/src/ex_banking_currency_server.erl:70: The inferred return type of handle_cast/2 
         ({'stop', _}) has nothing in common with 
          {'noreply', _} |
          {'noreply', _,
           'hibernate' | 'infinity' |
           non_neg_integer() |
           {'continue', _}} |
          {'stop', _, _}, which is the expected return type for the callback of the gen_server behaviour

/Users/iqltd/clones/BankingApp/src/ex_banking_currency_server.erl:89: The attempt to match a term of type 
          dict:dict(_, _) against the pattern 
          {'state', _} breaks the opacity of the term
```